### PR TITLE
#145: Refactorizar asociados

### DIFF
--- a/frontend/orbiflow/src/app/interfaces/User.ts
+++ b/frontend/orbiflow/src/app/interfaces/User.ts
@@ -10,6 +10,7 @@ export interface User {
   role: RolEnum;
   is_coop_member: boolean;
   is_active: boolean;
+  is_staff?: boolean;
   is_superuser?: boolean;
   is_deleted?: boolean;
   date_joined: string;

--- a/frontend/orbiflow/src/app/interfaces/User.ts
+++ b/frontend/orbiflow/src/app/interfaces/User.ts
@@ -10,7 +10,6 @@ export interface User {
   role: RolEnum;
   is_coop_member: boolean;
   is_active: boolean;
-  is_staff?: boolean;
   is_superuser?: boolean;
   is_deleted?: boolean;
   date_joined: string;

--- a/frontend/orbiflow/src/app/pages/asociados/page-asociados.html
+++ b/frontend/orbiflow/src/app/pages/asociados/page-asociados.html
@@ -198,7 +198,7 @@
     <div class="app-modal-field">
       <label>Usuario vinculado</label>
       @if (availableUsers.length === 0) {
-        <p class="modal-hint">No hay usuarios disponibles sin legajo (deben no ser staff). Creá uno primero desde Gestión de Usuarios.</p>
+        <p class="modal-hint">No hay coop members disponibles sin legajo. Creá uno primero desde Gestión de Usuarios (marcar como coop member).</p>
       } @else {
         <select
           class="form-select"

--- a/frontend/orbiflow/src/app/pages/asociados/page-asociados.html
+++ b/frontend/orbiflow/src/app/pages/asociados/page-asociados.html
@@ -198,7 +198,7 @@
     <div class="app-modal-field">
       <label>Usuario vinculado</label>
       @if (availableUsers.length === 0) {
-        <p class="modal-hint">No hay usuarios con rol Asociado sin legajo. Creá uno primero desde Gestión de Usuarios.</p>
+        <p class="modal-hint">No hay usuarios disponibles sin legajo (deben no ser staff). Creá uno primero desde Gestión de Usuarios.</p>
       } @else {
         <select
           class="form-select"

--- a/frontend/orbiflow/src/app/pages/asociados/page-asociados.ts
+++ b/frontend/orbiflow/src/app/pages/asociados/page-asociados.ts
@@ -204,13 +204,13 @@ export class PageAsociados implements OnInit {
 
     this.userService.getUsers().subscribe({
       next: (users) => {
-        // Excluye usuarios ya vinculados a un legajo, eliminados, o que sean staff
+        // Excluye usuarios ya vinculados a un legajo, eliminados, o que no sean coop members
         const linked = new Set<number>(
           this.associateList.map((a) => a.user).filter((v): v is number => typeof v === 'number'),
         );
-        // Permitir cualquier usuario que no sea staff (puede tener cualquier rol)
+        // Permitir usuarios que sean coop members (necesitan legajo, independientemente del rol)
         this.availableUsers = users.filter(
-          (u) => !u.is_staff && u.id != null && !linked.has(u.id) && !u.is_deleted,
+          (u) => u.is_coop_member && u.id != null && !linked.has(u.id) && !u.is_deleted,
         );
         console.log('Available users for new associate:', this.availableUsers);
         // Abre el modal solo cuando el select ya tiene opciones cargadas

--- a/frontend/orbiflow/src/app/pages/asociados/page-asociados.ts
+++ b/frontend/orbiflow/src/app/pages/asociados/page-asociados.ts
@@ -204,13 +204,13 @@ export class PageAsociados implements OnInit {
 
     this.userService.getUsers().subscribe({
       next: (users) => {
-        // Excluye usuarios ya vinculados a un legajo, eliminados, o sin rol 'associate'
+        // Excluye usuarios ya vinculados a un legajo, eliminados, o que sean staff
         const linked = new Set<number>(
           this.associateList.map((a) => a.user).filter((v): v is number => typeof v === 'number'),
         );
-        // El backend devuelve role='associate' (ver ROLE_CHOICES en identity.py)
+        // Permitir cualquier usuario que no sea staff (puede tener cualquier rol)
         this.availableUsers = users.filter(
-          (u) => (u.role as string) === 'associate' && u.id != null && !linked.has(u.id) && !u.is_deleted,
+          (u) => !u.is_staff && u.id != null && !linked.has(u.id) && !u.is_deleted,
         );
         console.log('Available users for new associate:', this.availableUsers);
         // Abre el modal solo cuando el select ya tiene opciones cargadas


### PR DESCRIPTION
#145: Refactorizar asociados — Permitir legajos a cualquier coop member
Cambio:
Antes: Solo usuarios con role === 'associate' podían tener legajo
Después: Cualquier usuario con is_coop_member === true puede tener legajo