### PR TITLE
fix(auth): redirigir a login cuando el token es inválido (#93)

### DIFF
--- a/frontend/orbiflow/src/app/app.ts
+++ b/frontend/orbiflow/src/app/app.ts
@@ -24,13 +24,14 @@ export class App implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    // Si hay token guardado, verificar que sea válido con el backend
+    // Verificar token al iniciar: si es inválido (401) o hay error de red (0), redirigir a login
     if (this.authService.isAuthenticated()) {
       this.authService.loadCurrentUser().subscribe({
-        error: () => {
-          // Token inválido o expirado, redirigir a login
-          this.authService.logout();
-          this.router.navigate(['/login']);
+        error: (err) => {
+          if (err.status === 401 || err.status === 0) {
+            this.authService.logout();
+            this.router.navigate(['/login']);
+          }
         },
       });
     }

--- a/frontend/orbiflow/src/app/app.ts
+++ b/frontend/orbiflow/src/app/app.ts
@@ -1,4 +1,4 @@
-import { Component, signal } from '@angular/core';
+import { Component, OnInit, signal } from '@angular/core';
 import { Router, RouterOutlet } from '@angular/router';
 import { NgClass } from '@angular/common';
 
@@ -13,7 +13,7 @@ import { Sidenav } from './shared/sidenav/sidenav';
   templateUrl: './app.html',
   styleUrl: './app.css',
 })
-export class App {
+export class App implements OnInit {
   protected readonly title = signal('orbiflow');
 
   sidebarExpanded = true;
@@ -22,6 +22,19 @@ export class App {
     private readonly router: Router,
     private readonly authService: AuthService,
   ) {}
+
+  ngOnInit(): void {
+    // Si hay token guardado, verificar que sea válido con el backend
+    if (this.authService.isAuthenticated()) {
+      this.authService.loadCurrentUser().subscribe({
+        error: () => {
+          // Token inválido o expirado, redirigir a login
+          this.authService.logout();
+          this.router.navigate(['/login']);
+        },
+      });
+    }
+  }
 
   showShell(): boolean {
     return (

--- a/frontend/orbiflow/src/app/core/auth/auth.interceptor.ts
+++ b/frontend/orbiflow/src/app/core/auth/auth.interceptor.ts
@@ -1,10 +1,14 @@
 import { HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
+import { Router } from '@angular/router';
+import { catchError, throwError } from 'rxjs';
 
 import { AuthService } from './auth.service';
 
 export const authInterceptor: HttpInterceptorFn = (request, next) => {
-  const token = inject(AuthService).getAccessToken();
+  const authService = inject(AuthService);
+  const router = inject(Router);
+  const token = authService.getAccessToken();
 
   if (!token) {
     return next(request);
@@ -15,6 +19,14 @@ export const authInterceptor: HttpInterceptorFn = (request, next) => {
       setHeaders: {
         Authorization: `Bearer ${token}`,
       },
+    }),
+  ).pipe(
+    catchError((error) => {
+      if (error.status === 401) {
+        authService.logout();
+        router.navigate(['/login']);
+      }
+      return throwError(() => error);
     }),
   );
 };


### PR DESCRIPTION
Implementa redirección automática a /login cuando:
- El token JWT es inválido o expiró (401)
- Hay error de conexión con el backend (0)
 
Cambios:
- auth.interceptor.ts: captura errores 401 y redirige a login
- app.ts: verifica token al iniciar la app, redirige si falla